### PR TITLE
Add response validation for non GPU sqreamd worker

### DIFF
--- a/pysqream/cursor.py
+++ b/pysqream/cursor.py
@@ -100,8 +100,13 @@ class Cursor:
                 self.conn.service, self.conn.database, self.conn.connection_id,
                 self.lb_params['listener_id'], self.conn.username, self.conn.password)
             self.client.send_string(reconnect_str)
-            self.client.send_string('{{"reconstructStatement": {}}}'.format(
-                self.stmt_id))
+            # Since summer 2024 sqreamd worker could be configured with non-gpu (cpu) instance
+            # it raises exception here like `The query requires a GPU-Worker. Ensure the SQream Service has GPU . . .`
+            # This exception should be validated here. Otherwise, it will be validated at the next call which provides
+            # Unexpected behavior
+            self.client.validate_response(
+                self.client.send_string('{{"reconstructStatement": {}}}'.format(self.stmt_id)),
+                "statementReconstructed")
 
         # Reconnected/reconstructed if needed,  send  execute command
         self.client.validate_response(self.client.send_string('{"execute" : "execute"}'), 'executed')


### PR DESCRIPTION
## Problem

Using pysqream connector with non-GPU sqreamd worker configuration and execute some DQL raises
`Unexpected message type. Waiting for GetStatementId, got 7Execute`
instead of: 
`The query requires a GPU-Worker. Ensure the SQream Service has GPU-Workers assigned`

## Solution

Since sqreamd support non-GPU configuration, we need to validate `reconstructStatement` request also.

The reason of that validation is handling exception `The query requires a GPU-Worker. Ensure the SQream Service has GPU-Workers assigned`

Otherwise we have a bottleneck: If we do not validate response - next request (`execute`) could be validated wrong. With unexpected behavior or errors like: `Unexpected message type. Waiting for GetStatementId, got 7Execute`